### PR TITLE
New email verification requirements

### DIFF
--- a/playwright-e2e/page-objects/pages/page.fixtures.ts
+++ b/playwright-e2e/page-objects/pages/page.fixtures.ts
@@ -41,6 +41,7 @@ import PTPHPage from "./case/ptph.page.ts";
 import AccessPage from "./case/access.page.ts";
 import AddEmailDomainPage from "./case/addEmailDomain.page.ts";
 import EditHearingDatePage from "./case/editHearingDate.page.ts";
+import EmailVerificationRequiredPage from "./platform/register/emailVerificationRequired.page.ts";
 
 /**
  * Interface defining the types of all available Page Object fixtures.
@@ -80,6 +81,7 @@ export interface PageFixtures {
   accessPage: AccessPage;
   addEmailDomainPage: AddEmailDomainPage;
   editHearingDatePage: EditHearingDatePage;
+  emailVerificationRequiredPage: EmailVerificationRequiredPage;
 }
 
 /**
@@ -184,5 +186,8 @@ export const pageFixtures = {
   },
   editHearingDatePage: async ({ page }, use) => {
     await use(new EditHearingDatePage(page));
+  },
+  emailVerificationRequiredPage: async ({ page }, use) => {
+    await use(new EmailVerificationRequiredPage(page));
   },
 };

--- a/playwright-e2e/page-objects/pages/platform/register/emailVerificationRequired.page.ts
+++ b/playwright-e2e/page-objects/pages/platform/register/emailVerificationRequired.page.ts
@@ -1,0 +1,28 @@
+import { Locator, expect } from "@playwright/test";
+import { Base } from "../../../base.ts";
+
+/**
+ * Represents the "Email Verification Required" page.
+ * This Page Object contains locators and a method to confirm that a newly registered user
+ * will be shown this page
+ * 1) Immediately after submitting their registration details prior to email verification
+ * 2) As a result of any attempt to log in with their user details prior to email verification
+ */
+
+class EmailVerificationRequiredPage extends Base {
+  requiresEmailVerificationText: Locator;
+
+  constructor(page) {
+    super(page);
+    this.requiresEmailVerificationText = page.getByText(
+      "We need to verify your email address. We have sent a verification email to the following address:",
+    );
+  }
+
+  async confirmAccountAwaitingEmailVerification(emailAddress: string) {
+    await expect(this.requiresEmailVerificationText).toBeVisible();
+    await expect(this.page.getByText(emailAddress)).toBeVisible();
+    await expect(this.navigation.links.LogOn).toBeVisible();
+  }
+}
+export default EmailVerificationRequiredPage;

--- a/playwright-e2e/tests/registerUser.spec.ts
+++ b/playwright-e2e/tests/registerUser.spec.ts
@@ -54,6 +54,7 @@ test.describe("@nightly @regression Register New user in CCDCS", () => {
     approvalRequestsPage,
     approveAccessRequestPage,
     rejectAccessRequestPage,
+    emailVerificationRequiredPage,
   }) => {
     // New user completes registration form
 
@@ -61,11 +62,23 @@ test.describe("@nightly @regression Register New user in CCDCS", () => {
     await expect(registerUserPage.registerHeading).toContainText("Register");
     const { userName, userEmail, userRole, userLocation, isSelfInviteRole } =
       await registerUserPage.submitUserRegDetails();
-    await homePage.navigation.logOff();
+
+    // Ensure newly registered users do not have access to the platform prior to
+    // email verification
+
+    // 'Verification required' shown immediately after submitting registration details
+    await emailVerificationRequiredPage.confirmAccountAwaitingEmailVerification(
+      userEmail,
+    );
+    await emailVerificationRequiredPage.navigation.navigateTo("LogOn");
+    await loginPage.loginAsNewUserRegistered(userEmail);
+    // 'Verification required' shown after any login attempt prior to email verification
+    await emailVerificationRequiredPage.confirmAccountAwaitingEmailVerification(
+      userEmail,
+    );
 
     // Access Coordinator verifies the new user's email
-
-    await homePage.navigation.navigateTo("LogOn");
+    await emailVerificationRequiredPage.navigation.navigateTo("LogOn");
     await loginPage.loginAsAccessCoordinator();
     await homePage.navigation.navigateTo("Admin");
     await expect(adminPage.adminHeading).toContainText(


### PR DESCRIPTION
New email verification requirements.
A user needs to verify their email post registration before they can access the platform. 
New page - emailVerificationRequiredPage
