### PR TITLE
Additional Page functionality automated tests

### DIFF
--- a/playwright-e2e/page-objects/pages/case/createCase.page.ts
+++ b/playwright-e2e/page-objects/pages/case/createCase.page.ts
@@ -72,7 +72,7 @@ class CreateCasePage extends Base {
   }
 
   async handleUrnField(prosecutedBy: string, newCaseUrn: string) {
-    if (prosecutedBy === "CPS") {
+    if (prosecutedBy === "CPS" || prosecutedBy === "NSL Test") {
       await expect(this.caseUrn).toBeEnabled({ timeout: 10_000 });
       await this.caseUrn.fill(newCaseUrn);
     } else {

--- a/playwright-e2e/page-objects/pages/case/reviewEvidence/pagesComponent.ts
+++ b/playwright-e2e/page-objects/pages/case/reviewEvidence/pagesComponent.ts
@@ -15,6 +15,12 @@ class PagesComponent extends Base {
   pagesMenuLink: Locator;
   goToPageLink: Locator;
   goToPageInput: Locator;
+  nextDocumentLink: Locator;
+  previousDocumentLink: Locator;
+  pageDirectionLink: Locator;
+  pageDirectionSuccessfulTick: Locator;
+  pageDirectionPopup: Locator;
+  jumpToPageDirection: Locator;
 
   constructor(page) {
     super(page);
@@ -22,26 +28,30 @@ class PagesComponent extends Base {
     this.pagesMenuLink = this.topMenu.locator("#rmiPage");
     this.goToPageLink = page.locator("#goToPage");
     this.goToPageInput = page.locator("#goToPageNumberInput");
+    this.nextDocumentLink = page.locator("#nextDiv");
+    this.previousDocumentLink = page.locator("#previousDiv");
+    this.pageDirectionLink = page.locator("#displayToCourt");
+    this.pageDirectionSuccessfulTick = this.pageDirectionLink.locator("img");
+    this.pageDirectionPopup = page.locator("#confirmJumpPopupDiv");
+    this.jumpToPageDirection = page.locator("#jumpYes");
   }
 
-  async openPages() {
+  async openPages(link: Locator) {
+    const durationMs = 1_000;
+    const intervalMs = 200;
+    const start = Date.now();
+
     await expect(this.pagesMenuLink).toBeVisible();
     await this.pagesMenuLink.click();
+
+    while (Date.now() - start < durationMs) {
+      await expect(link).toBeVisible();
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
   }
 
   async goToPage(pageNumber: string) {
-    await expect(this.pagesMenuLink).toBeVisible();
-    await expect
-      .poll(
-        async () => {
-          await this.pagesMenuLink.click();
-          return this.goToPageLink.isVisible();
-        },
-        {
-          timeout: 5000,
-        },
-      )
-      .toBe(true);
+    await this.openPages(this.goToPageLink);
     await this.goToPageLink.click();
     try {
       await expect
@@ -61,6 +71,63 @@ class PagesComponent extends Base {
     await this.goToPageInput.fill(pageNumber);
     await expect(this.goToPageInput).toHaveValue(pageNumber);
     await this.goToPageInput.press("Enter");
+  }
+
+  async getNavigationDirection(
+    fromSection: string,
+    toSection: string,
+  ): Promise<"next" | "previous"> {
+    return toSection.localeCompare(fromSection) <= 0 ? "previous" : "next";
+  }
+
+  async goToNextDocument() {
+    await this.openPages(this.nextDocumentLink);
+    await this.nextDocumentLink.click();
+  }
+
+  async goToPreviousDocument() {
+    await this.openPages(this.previousDocumentLink);
+    await this.previousDocumentLink.click();
+  }
+
+  async selectPageDirection() {
+    await this.openPages(this.pageDirectionLink);
+    await this.pageDirectionLink.click();
+    await expect
+      .poll(
+        async () => {
+          return this.pageDirectionSuccessfulTick.isVisible();
+        },
+        {
+          timeout: 10000,
+        },
+      )
+      .toBe(true);
+  }
+
+  async validateNoPageDirection() {
+    const durationMs = 15000;
+    const intervalMs = 200;
+    const start = Date.now();
+
+    while (Date.now() - start < durationMs) {
+      await expect(this.pageDirectionPopup).toBeHidden();
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+  }
+
+  async acceptPageDirection() {
+    await expect
+      .poll(
+        async () => {
+          return await this.pageDirectionPopup.isVisible();
+        },
+        {
+          timeout: 15000,
+        },
+      )
+      .toBe(true);
+    await this.jumpToPageDirection.click();
   }
 }
 

--- a/playwright-e2e/tests/reviewEvidence-pages.spec.ts
+++ b/playwright-e2e/tests/reviewEvidence-pages.spec.ts
@@ -403,8 +403,13 @@ test.describe("@regression Document Access Validation via Pages", () => {
     );
 
     // Attempt to navigate to an unathorised document as Defence Advocate B via Page Direction popup
-    //TBC awaiting Bug Ticket review and confirmed approach to popup visbility.
+    // This approach will change - issue raised that Defence B should not receive page direction popup.
+    // Once changes are made update to the line below.
     // await reviewEvidencePageDefenceB.pages.validateNoPageDirection();
+
+    await reviewEvidencePageDefenceB.pages.acceptPageDirection();
+
+    await reviewEvidencePageDefenceB.confirmDocumentPage(documentKeyDefenceB);
 
     await popupDefenceB.close();
     await sectionDocumentsPage.navigation.logOff();

--- a/playwright-e2e/tests/reviewEvidence-pages.spec.ts
+++ b/playwright-e2e/tests/reviewEvidence-pages.spec.ts
@@ -36,6 +36,7 @@ test.describe("@regression Document Access Validation via Pages", () => {
   let documentKeyDefenceA: string;
   let documentKeyDefenceB: string;
   let sectionDefenceA: string;
+  let sectionDefenceB: string;
 
   test.beforeEach(
     async ({
@@ -93,19 +94,21 @@ test.describe("@regression Document Access Validation via Pages", () => {
       // a) To enable the Review Evidence Page to open (otherwise Defence Advocate B will have no accesible documents to review)
       // b) To enable distinction between accessible and inaccessible documents
       // Access to this document is restricted to Defence Advocates for Defendant Two (B, C)
-      const { documentKey: docKeyDefB } = await uploadRestrictedDocument(
-        homePage,
-        loginPage,
-        caseSearchPage,
-        caseDetailsPage,
-        sectionsPage,
-        sectionDocumentsPage,
-        config.users.defenceAdvocateB,
-        newCaseName,
-        docDefendantTwo,
-        [nameDefendantTwo],
-      );
+      const { sectionName: sectionDefenceB_name, documentKey: docKeyDefB } =
+        await uploadRestrictedDocument(
+          homePage,
+          loginPage,
+          caseSearchPage,
+          caseDetailsPage,
+          sectionsPage,
+          sectionDocumentsPage,
+          config.users.defenceAdvocateB,
+          newCaseName,
+          docDefendantTwo,
+          [nameDefendantTwo],
+        );
       documentKeyDefenceB = docKeyDefB;
+      sectionDefenceB = sectionDefenceB_name;
     },
   );
 
@@ -249,6 +252,185 @@ test.describe("@regression Document Access Validation via Pages", () => {
 
     // Use the Go To Page input to navigate to Defence Advocate A's document
     await reviewEvidencePageDefenceC.pages.goToPage(sectionDefenceA + "1");
+
+    await reviewEvidencePageDefenceC.waitForHighResImageLoadByDocument(
+      documentKeyDefenceA,
+      docDefendantOne,
+    );
+
+    expect(await reviewEvidencePageDefenceC.getCurrentDocumentKey()).toBe(
+      documentKeyDefenceA,
+    );
+  });
+
+  // ============================================================
+  // Scenario 3
+  // ============================================================
+
+  // When Defence Advocate A uploads a restricted document
+  // If Defence Advocate B uses the Next & Previous Document functionality - Then Defence Advocate B should not be able to navigate to the restricted document
+  // If Defence Advocate C uses the Next & Previous Document functionality - Then Defence Advocate C should be able to navigate to the restricted document
+
+  test("Document Access Validation via the Pages 'Next' & 'Previous' Page Functionality", async ({
+    loginPage,
+    homePage,
+    caseDetailsPage,
+    caseSearchPage,
+    sectionDocumentsPage,
+  }) => {
+    // Open the Review Evidence page as Defence Advocate B
+
+    const popup = await openReviewPopupAwaitPagination(sectionDocumentsPage);
+    const reviewEvidencePage = new ReviewEvidencePage(popup);
+
+    await reviewEvidencePage.sectionPanelLoad();
+    await reviewEvidencePage.waitForHighResImageLoadByDocument(
+      documentKeyDefenceB,
+      docDefendantTwo,
+    );
+
+    // Attempt to navigate to an unathorised document page as Defence Advocate B via Next and Previous page links
+
+    const direction = await reviewEvidencePage.pages.getNavigationDirection(
+      sectionDefenceB,
+      sectionDefenceA,
+    );
+
+    await {
+      next: () => reviewEvidencePage.pages.goToNextDocument(),
+      previous: () => reviewEvidencePage.pages.goToPreviousDocument(),
+    }[direction]();
+
+    await reviewEvidencePage.confirmDocumentPage(documentKeyDefenceB);
+
+    await popup.close();
+    await sectionDocumentsPage.navigation.navigateTo("LogOff");
+
+    // Validate Defence Advocate C can access Defence Advocate A's document via Next & Previous link functionalilty
+    await loginAndOpenCase(
+      homePage,
+      loginPage,
+      caseSearchPage,
+      config.users.defenceAdvocateC,
+      newCaseName,
+    );
+
+    // Open the Review page
+    const popupDefenceC = await openReviewPopupAwaitPagination(caseDetailsPage);
+    const reviewEvidencePageDefenceC = new ReviewEvidencePage(popupDefenceC);
+
+    await reviewEvidencePageDefenceC.sectionPanelLoad();
+
+    // Ensure we start from Defence Advocate B's document before attempting Next document functionality
+    await reviewEvidencePageDefenceC.ensureDocumentIsOpen(
+      documentKeyDefenceB,
+      docDefendantTwo,
+    );
+
+    await {
+      next: () => reviewEvidencePageDefenceC.pages.goToNextDocument(),
+      previous: () => reviewEvidencePageDefenceC.pages.goToPreviousDocument(),
+    }[direction]();
+
+    await reviewEvidencePageDefenceC.waitForHighResImageLoadByDocument(
+      documentKeyDefenceA,
+      docDefendantOne,
+    );
+
+    expect(await reviewEvidencePageDefenceC.getCurrentDocumentKey()).toBe(
+      documentKeyDefenceA,
+    );
+  });
+
+  // ============================================================
+  // Scenario 4
+  // ============================================================
+
+  // When Defence Advocate A uploads a restricted document
+  // If Defence Advocate A uses the 'Page Direction' functionality - Then Defence Advocate B should not be able to navigate to the restricted document via the Page Direction popup
+  // If Defence Advocate A uses the 'Page Direction' functionality - Then Defence Advocate C should be able to navigate to the restricted document via the Page Direction popup
+
+  test("Document Access Validation via the Pages 'Page Direction' Functionality", async ({
+    loginPage,
+    homePage,
+    caseDetailsPage,
+    caseSearchPage,
+    sectionDocumentsPage,
+  }) => {
+    await sectionDocumentsPage.navigation.logOff();
+
+    // Login as Defence Advocate A
+    await loginAndOpenCase(
+      homePage,
+      loginPage,
+      caseSearchPage,
+      config.users.defenceAdvocateA,
+      newCaseName,
+    );
+
+    // Open the Review page
+    const popupDefenceA = await openReviewPopupAwaitPagination(caseDetailsPage);
+    const reviewEvidencePageDefenceA = new ReviewEvidencePage(popupDefenceA);
+
+    await reviewEvidencePageDefenceA.sectionPanelLoad();
+
+    // Navigate to Page panel, and click the Page Direction button
+
+    await reviewEvidencePageDefenceA.pages.selectPageDirection();
+    await popupDefenceA.close();
+    await sectionDocumentsPage.navigation.logOff();
+
+    // Login as Defence Advocate B
+
+    await loginAndOpenCase(
+      homePage,
+      loginPage,
+      caseSearchPage,
+      config.users.defenceAdvocateB,
+      newCaseName,
+    );
+
+    // Open the Review Evidence page
+
+    const popupDefenceB =
+      await openReviewPopupAwaitPagination(sectionDocumentsPage);
+    const reviewEvidencePageDefenceB = new ReviewEvidencePage(popupDefenceB);
+
+    await reviewEvidencePageDefenceB.sectionPanelLoad();
+    await reviewEvidencePageDefenceB.waitForHighResImageLoadByDocument(
+      documentKeyDefenceB,
+      docDefendantTwo,
+    );
+
+    // Attempt to navigate to an unathorised document as Defence Advocate B via Page Direction popup
+    //TBC awaiting Bug Ticket review and confirmed approach to popup visbility.
+    // await reviewEvidencePageDefenceB.pages.validateNoPageDirection();
+
+    await popupDefenceB.close();
+    await sectionDocumentsPage.navigation.logOff();
+
+    // Validate Defence Advocate C can access Defence Advocate A's document via Page Direction popup
+    await loginAndOpenCase(
+      homePage,
+      loginPage,
+      caseSearchPage,
+      config.users.defenceAdvocateC,
+      newCaseName,
+    );
+
+    // Open the Review page
+    const popupDefenceC = await openReviewPopupAwaitPagination(caseDetailsPage);
+    const reviewEvidencePageDefenceC = new ReviewEvidencePage(popupDefenceC);
+
+    await reviewEvidencePageDefenceC.sectionPanelLoad();
+
+    // Ensure we start from Defence Advocate B's document before attempting Next document functionality
+    await reviewEvidencePageDefenceC.ensureDocumentIsOpen(
+      documentKeyDefenceB,
+      docDefendantTwo,
+    );
+
+    await reviewEvidencePageDefenceC.pages.acceptPageDirection();
 
     await reviewEvidencePageDefenceC.waitForHighResImageLoadByDocument(
       documentKeyDefenceA,


### PR DESCRIPTION
Scenario 3

  When Defence Advocate A uploads a restricted document
  If Defence Advocate B uses the Next & Previous Document functionality - Then Defence Advocate B should not be able to navigate to the restricted document
  If Defence Advocate C uses the Next & Previous Document functionality - Then Defence Advocate C should be able to navigate to the restricted document


  Scenario 4

  When Defence Advocate A uploads a restricted document
  If Defence Advocate A uses the 'Page Direction' functionality - Then Defence Advocate B should not be able to navigate to the restricted document via the Page Direction popup
  If Defence Advocate A uses the 'Page Direction' functionality - Then Defence Advocate C should be able to navigate to the restricted document via the Page Direction popup